### PR TITLE
Added opt-in root auth scoping

### DIFF
--- a/lib/restHandler.js
+++ b/lib/restHandler.js
@@ -36,6 +36,15 @@ const DEFAULT_LIMIT = 100;
   *		specific fields from all restrictions suring construction)
   * @param {integer} options.defaultPageLength Default limit for pagination
   *
+  * @param {function} options.authorizationScope Callback function used to produce
+  *   a include scope specific to a controllers relational models. Used for limiting
+  *   find and show operations of models to specific organisations. Uses Koa context
+  *   as primary argument.
+  *
+  * @param {function} options.skipAuthorizationScope Callback function used to
+  *   negate the effects of a given options.authorizationScope if a truthy value
+  *   is returned. Uses Koa context as primary argument.
+  *
   * @example
   * scopeModels = ['user'];
   *
@@ -113,7 +122,7 @@ class RestHandler extends events.EventEmitter {
 		}
 
 		this.authorizationScope = options.authorizationScope;
-		this.rootAuthorizationScope = options.rootAuthorizationScope;
+		this.skipAuthorizationScope = options.skipAuthorizationScope;
 	}
 
 	/**
@@ -163,8 +172,8 @@ class RestHandler extends events.EventEmitter {
 	 */
 	includeAuthorizationScope(ctx, include) {
 		if (this.authorizationScope) {
-			// if root user then passthrough includes (allow all)
-			if (this.rootAuthorizationScope && this.rootAuthorizationScope(ctx)) {
+			// if scope is negatable then passthrough includes (allow all)
+			if (this.skipAuthorizationScope && this.skipAuthorizationScope(ctx)) {
 				return include;
 			}
 

--- a/lib/restHandler.js
+++ b/lib/restHandler.js
@@ -113,6 +113,7 @@ class RestHandler extends events.EventEmitter {
 		}
 
 		this.authorizationScope = options.authorizationScope;
+		this.rootAuthorizationScope = options.rootAuthorizationScope;
 	}
 
 	/**
@@ -152,6 +153,26 @@ class RestHandler extends events.EventEmitter {
 		const where = {};
 		where[key] = record[key];
 		return where;
+	}
+
+	/**
+	 * Conditionally bind includes to limit show and index operations to a specific scope
+	 * @param  {Context} ctx The Koa context
+	 * @param  {Object} include The include object to process
+	 * @return {Object} The mutated include object
+	 */
+	includeAuthorizationScope(ctx, include) {
+		if (this.authorizationScope) {
+			// if root user then passthrough includes (allow all)
+			if (this.rootAuthorizationScope && this.rootAuthorizationScope(ctx)) {
+				return include;
+			}
+
+			// assign the authorizationScope based on the ctx's user
+			return mergeIncludes([this.authorizationScope(ctx)], include);
+		}
+
+		return include;
 	}
 
 	/**
@@ -279,10 +300,7 @@ class RestHandler extends events.EventEmitter {
 
 		const q = Object.assign({ where: this.whereByAlias(ctx.params[paramName(this.name)]) }, query);
 
-		if (this.authorizationScope) {
-			// assign the authorizationScope based on the ctx's user
-			include = mergeIncludes([this.authorizationScope(ctx.state.user)], include);
-		}
+		include = this.includeAuthorizationScope(ctx, include);
 
 		if (include) q.include = include;
 
@@ -316,10 +334,7 @@ class RestHandler extends events.EventEmitter {
 		const where = opts.where || ctx.where || {};
 		const query = opts.query || {};
 
-		if (this.authorizationScope) {
-			// assign the authorizationScope based on the ctx's user
-			include = mergeIncludes([this.authorizationScope(ctx.state.user)], include);
-		}
+		include = this.includeAuthorizationScope(ctx, include);
 
 		where[Op.and] = where[Op.and] || [];
 


### PR DESCRIPTION
Allows the opt-in passing of `rootAuthorizationScope`, which is a function that allows the overriding of a provided `authorizationScope` if the condition resolved from `rootAuthorizationScope` is true.

Also changes `ctx.state.user` to `ctx` for auth passthrough.